### PR TITLE
fix: the tmpnam implementation uses strcpy without a... in tmpnam.c

### DIFF
--- a/patches/musl/zig/lib/libc/musl/src/stdio/tmpnam.c
+++ b/patches/musl/zig/lib/libc/musl/src/stdio/tmpnam.c
@@ -24,8 +24,11 @@ char *tmpnam(char *buf)
 #else
 		r = __syscall(SYS_readlinkat, AT_FDCWD, s, (char[1]){0}, 1);
 #endif
-		if (r == -ENOENT)
-			return strcpy(buf ? buf : internal, s);
+		if (r == -ENOENT) {
+			char *dst = buf ? buf : internal;
+			snprintf(dst, L_tmpnam, "%s", s);
+			return dst;
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
## Summary
Fix high severity security issue in `patches/musl/zig/lib/libc/musl/src/stdio/tmpnam.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `patches/musl/zig/lib/libc/musl/src/stdio/tmpnam.c:28` |
| **CWE** | CWE-120 |

**Description**: The tmpnam implementation uses strcpy without any bounds checking to copy the generated temporary file name string 's' into either the caller-supplied buffer 'buf' or the static 'internal' buffer. Because strcpy copies bytes until a null terminator is found in the source with no regard for the destination buffer size, any scenario where 's' exceeds L_tmpnam bytes — such as a developer modifying the name-generation logic or a caller passing an undersized buffer — will cause a stack or heap buffer overflow. This is a patched copy of musl libc in a custom Zig toolchain tree, making it more susceptible to inadvertent modification than an upstream-managed library.

## Changes
- `patches/musl/zig/lib/libc/musl/src/stdio/tmpnam.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
